### PR TITLE
친구 요청 기능 추가

### DIFF
--- a/src/main/java/com/jungmini/pay/common/resolover/SigninMemberArgumentResolver.java
+++ b/src/main/java/com/jungmini/pay/common/resolover/SigninMemberArgumentResolver.java
@@ -44,7 +44,7 @@ public class SigninMemberArgumentResolver implements HandlerMethodArgumentResolv
 
     private static void checkAuthorization(String token) {
         if (token == null || token.length() == 0) {
-            throw new PayException(ErrorCode.SIGN_IN_REQUIRED);
+            throw new PayException(ErrorCode.UN_AUTHORIZED);
         }
     }
 }

--- a/src/main/java/com/jungmini/pay/controller/FriendController.java
+++ b/src/main/java/com/jungmini/pay/controller/FriendController.java
@@ -2,6 +2,7 @@ package com.jungmini.pay.controller;
 
 import com.jungmini.pay.common.resolover.SigninMember;
 import com.jungmini.pay.controller.dto.FriendDTO;
+import com.jungmini.pay.domain.Friend;
 import com.jungmini.pay.domain.FriendRequest;
 import com.jungmini.pay.domain.Member;
 import com.jungmini.pay.service.FriendService;
@@ -9,10 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -46,6 +44,19 @@ public class FriendController {
                 .build());
     }
 
+    @PostMapping("/friends/requests/accept/{id}")
+    public ResponseEntity<FriendDTO.AcceptFriendRequestResponse> acceptFriendRequest(
+            @PathVariable long id,
+            @SigninMember Member signinMember
+    ) {
+        Friend friend = friendService.acceptFriendRequest(id);
+        return ResponseEntity.ok(FriendDTO.AcceptFriendRequestResponse
+                .builder()
+                .message(String.format("%s님의 친구 요청 수락 완료", friend.getRequester()))
+                .build());
+    }
+
+
     @GetMapping("/friends/request")
     public ResponseEntity<List<FriendDTO.FindFriendRequestResponse>> findFriendRequests(
             Pageable pageable,
@@ -53,7 +64,7 @@ public class FriendController {
     ) {
         List<FriendDTO.FindFriendRequestResponse> requesters =
                 friendService.findRequests(pageable, signinMember).stream()
-                .map(friendRequest -> FriendDTO.FindFriendRequestResponse.from(friendRequest.getRequester()))
+                .map(FriendDTO.FindFriendRequestResponse::from)
                 .toList();
 
         return ResponseEntity.ok(requesters);

--- a/src/main/java/com/jungmini/pay/controller/dto/FriendDTO.java
+++ b/src/main/java/com/jungmini/pay/controller/dto/FriendDTO.java
@@ -45,16 +45,26 @@ public class FriendDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class FindFriendRequestResponse {
+        private long id;
         private String email;
         private String name;
         private LocalDateTime createdAt;
 
-        public static FindFriendRequestResponse from(Member requester) {
+        public static FindFriendRequestResponse from(FriendRequest friendRequest) {
             return FindFriendRequestResponse.builder()
-                    .email(requester.getEmail())
-                    .name(requester.getName())
-                    .createdAt(requester.getCreatedAt())
+                    .id(friendRequest.getId())
+                    .email(friendRequest.getRequester().getEmail())
+                    .name(friendRequest.getRequester().getName())
+                    .createdAt(friendRequest.getCreatedAt())
                     .build();
         }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AcceptFriendRequestResponse {
+        private String message;
     }
 }

--- a/src/main/java/com/jungmini/pay/domain/Friend.java
+++ b/src/main/java/com/jungmini/pay/domain/Friend.java
@@ -21,4 +21,12 @@ public class Friend extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "friend_recipient_email")
     private Member recipient;
+
+    public static Friend from(FriendRequest friendRequest) {
+        return Friend.builder()
+                .requester(friendRequest.getRequester())
+                .recipient(friendRequest.getRecipient())
+                .build();
+    }
+
 }

--- a/src/main/java/com/jungmini/pay/domain/Member.java
+++ b/src/main/java/com/jungmini/pay/domain/Member.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false) // 부모 필드 값은 확인 안하도록 설정
 @Entity
 public class Member extends BaseTimeEntity {
 
@@ -16,10 +17,10 @@ public class Member extends BaseTimeEntity {
     private String email;
 
     @Column
-    private String password;
+    @EqualsAndHashCode.Exclude private String password;
 
     @Column
-    private String name;
+    @EqualsAndHashCode.Exclude private String name;
 
     public Member encodePassword(String encryptedPassword) {
         return Member.builder()

--- a/src/main/java/com/jungmini/pay/exception/ErrorCode.java
+++ b/src/main/java/com/jungmini/pay/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     ALREADY_FRIENDS("이미 친구 관계입니다."),
     FRIENDS_REQUEST_EXISTS("이미 친구 요청이 존재합니다."),
     SELF_FRIEND_REQUEST("스스로에게 친구 요청을 할 수 없습니다."),
-    SIGN_IN_REQUIRED("로그인이 필요 합니다.");
+    UN_AUTHORIZED("로그인이 필요 합니다.");
     private final String description;
 
 }

--- a/src/main/java/com/jungmini/pay/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jungmini/pay/exception/GlobalExceptionHandler.java
@@ -13,6 +13,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(PayException.class)
     public ResponseEntity<ErrorResponse> handlePayException(PayException e) {
+        if (e.getErrorCode().equals(ErrorCode.UN_AUTHORIZED.toString())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ErrorResponse.builder()
+                        .errorCode(e.getErrorCode())
+                        .message(e.getErrorMessage())
+                        .build());
+        }
+
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.builder()
                         .errorCode(e.getErrorCode())

--- a/src/main/java/com/jungmini/pay/service/FriendService.java
+++ b/src/main/java/com/jungmini/pay/service/FriendService.java
@@ -54,6 +54,7 @@ public class FriendService {
 
         Friend savedFriend = friendRepository.save(Friend.from(friendRequest));
         friendRequestRepository.deleteById(friendRequestId);
+
         return savedFriend;
     }
 

--- a/src/main/java/com/jungmini/pay/service/FriendService.java
+++ b/src/main/java/com/jungmini/pay/service/FriendService.java
@@ -1,5 +1,6 @@
 package com.jungmini.pay.service;
 
+import com.jungmini.pay.domain.Friend;
 import com.jungmini.pay.domain.FriendRequest;
 import com.jungmini.pay.domain.Member;
 import com.jungmini.pay.exception.ErrorCode;
@@ -8,12 +9,14 @@ import com.jungmini.pay.repository.FriendRepository;
 import com.jungmini.pay.repository.FriendRequestRepository;
 import com.jungmini.pay.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class FriendService {
@@ -42,6 +45,16 @@ public class FriendService {
     public List<FriendRequest> findRequests(Pageable pageable, Member recipient) {
         return friendRequestRepository
                 .findFriendRequestByRecipientOrderByCreatedAtDesc(recipient, pageable);
+    }
+
+    @Transactional
+    public Friend acceptFriendRequest(final long friendRequestId) {
+        FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
+                .orElseThrow(() -> new PayException(ErrorCode.BAD_REQUEST));
+
+        Friend savedFriend = friendRepository.save(Friend.from(friendRequest));
+        friendRequestRepository.deleteById(friendRequestId);
+        return savedFriend;
     }
 
     private void validationFriendRequest(FriendRequest request) {

--- a/src/test/http/friend.http
+++ b/src/test/http/friend.http
@@ -1,6 +1,6 @@
 ### 친구신청
 POST http://localhost:8080/friends/request
-Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0M0B0ZXN0LmNvbSIsImV4cCI6MTY3OTk5ODc4MH0.92qxa7vw7bC-eB6o2sWpb_aNdTwnihfyqz73XuAfjgGx5nAIEOSSBMISOSAN9TCI9ifAet2VSwSvQpZjKL1JGw
+Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0M0B0ZXN0LmNvbSIsImV4cCI6MTY4MDMzMzQ5NH0.x9TvUM1KET2qwBWbzi-BwNwNXH70lvUlS-tRFf5hxunf5SpJDE0r2jeDe_KR5EkuGxgojHjwO4pgjJ6uopjXsQ
 Content-Type: application/json
 
 {
@@ -9,8 +9,11 @@ Content-Type: application/json
   "email": "test@test.com"
 }
 
-### 친구목록 조회
+### 친구 요청 목록 조회
 GET http://localhost:8080/friends/request?size=4
-Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiZXhwIjoxNjc5OTk4ODIyfQ.DT-Ob560ZpaIaKmYWf-b7LkGg6pGq2v9Jrm3e-AtA_UVwhX0PouG-5Uk8M9IqFtEJLZMjsl6DTZpQ7HHbvRNJg
+Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiZXhwIjoxNjgwMzMzNTI2fQ.CZ5a04cd8aGsp_zBQFP600HRvkauFi1mZ3c7iorei_ta5J5gIR2v_hXF61GSKG3RCY6Y3mX7-aNAPiR86dzBKg
 Content-Type: application/json
 
+### 친구 요청 수락
+POST http://localhost:8080/friends/request
+Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiZXhwIjoxNjgwMzMzNTI2fQ.CZ5a04cd8aGsp_zBQFP600HRvkauFi1mZ3c7iorei_ta5J5gIR2v_hXF61GSKG3RCY6Y3mX7-aNAPiR86dzBKg

--- a/src/test/java/com/jungmini/pay/controller/FriendControllerTest.java
+++ b/src/test/java/com/jungmini/pay/controller/FriendControllerTest.java
@@ -179,7 +179,6 @@ public class FriendControllerTest {
 
         String token = tokenService.generateToken(recipient.getEmail());
 
-
         mvc.perform(post("/friends/requests/accept/1")
                     .header("Auth", token))
                 .andExpect(status().is2xxSuccessful())

--- a/src/test/java/com/jungmini/pay/controller/FriendControllerTest.java
+++ b/src/test/java/com/jungmini/pay/controller/FriendControllerTest.java
@@ -73,7 +73,7 @@ public class FriendControllerTest {
 
     @Test
     @DisplayName("통합 테스트 실패 - 친구 요청 토큰 X")
-    void createFriendRequest_fail_signin_required() throws Exception {
+    void createFriendRequest_fail_UnAuthorized() throws Exception {
         FriendRequest friendRequest = FriendRequestFactory.friendRequest();
 
         mvc.perform(
@@ -81,8 +81,8 @@ public class FriendControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(friendRequest.getRecipient().getEmail())))
                 .andExpect(status().is4xxClientError())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.SIGN_IN_REQUIRED.toString()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.SIGN_IN_REQUIRED.getDescription()))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.UN_AUTHORIZED.toString()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.UN_AUTHORIZED.getDescription()))
                 .andDo(print());
     }
 
@@ -164,6 +164,36 @@ public class FriendControllerTest {
                     get("/friends/request")
                     .header("Auth", token))
                 .andExpect(status().is2xxSuccessful())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("통합 테스트 성공 - 친구 요청 수락 성공")
+    void acceptFriendRequest_success() throws Exception {
+        FriendRequest friendRequest = FriendRequestFactory.friendRequest();
+        Member requester = friendRequest.getRequester();
+        Member recipient = friendRequest.getRecipient();
+        memberService.signUp(requester);
+        memberService.signUp(recipient);
+        friendService.requestFriend(friendRequest);
+
+        String token = tokenService.generateToken(recipient.getEmail());
+
+
+        mvc.perform(post("/friends/requests/accept/1")
+                    .header("Auth", token))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.message").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("통합 테스트 성공 - 친구 요청 토큰 X")
+    void acceptFriendRequest_fail_UnAuthorized() throws Exception {
+        mvc.perform(post("/friends/requests/accept/1"))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.UN_AUTHORIZED.toString()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.UN_AUTHORIZED.getDescription()))
                 .andDo(print());
     }
 }


### PR DESCRIPTION
feature 친구 요청 수락 기능 추가

단위 테스트 및 통합 테스트 작성 예외 상황 1. 친구 요청이 존재하지 않는 경우 고민해 본 추가 예외상황 친구 요청을 수락할 때 회원이 탈퇴하거나 하는 경우에는 cascade 이용하여 정합성 보장 DB에서 제어할 수 있는 정합성 문제는 어플리케이션에서 고려하지 않는다.