### PR TITLE
친구요청 거절 기능 추가

### DIFF
--- a/src/main/java/com/jungmini/pay/controller/FriendController.java
+++ b/src/main/java/com/jungmini/pay/controller/FriendController.java
@@ -55,6 +55,17 @@ public class FriendController {
                 .message(String.format("%s님의 친구 요청 수락 완료", friend.getRequester()))
                 .build());
     }
+    @PostMapping("/friends/requests/deny/{id}")
+    public ResponseEntity<FriendDTO.DenyFriendRequestResponse> denyFriendRequest(
+            @PathVariable long id,
+            @SigninMember Member signinMember
+    ) {
+        FriendRequest friendRequest = friendService.denyFriendRequest(id);
+        return ResponseEntity.ok(FriendDTO.DenyFriendRequestResponse
+                .builder()
+                .message(String.format("%s님의 친구 요청 거절 완료", friendRequest.getRequester().getEmail()))
+                .build());
+    }
 
 
     @GetMapping("/friends/request")

--- a/src/main/java/com/jungmini/pay/controller/dto/FriendDTO.java
+++ b/src/main/java/com/jungmini/pay/controller/dto/FriendDTO.java
@@ -67,4 +67,12 @@ public class FriendDTO {
     public static class AcceptFriendRequestResponse {
         private String message;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DenyFriendRequestResponse {
+        private String message;
+    }
 }

--- a/src/main/java/com/jungmini/pay/service/FriendService.java
+++ b/src/main/java/com/jungmini/pay/service/FriendService.java
@@ -58,6 +58,16 @@ public class FriendService {
         return savedFriend;
     }
 
+    @Transactional
+    public FriendRequest denyFriendRequest(final long friendRequestId) {
+        FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
+                .orElseThrow(() -> new PayException(ErrorCode.BAD_REQUEST));
+
+        friendRequestRepository.deleteById(friendRequestId);
+
+        return friendRequest;
+    }
+
     private void validationFriendRequest(FriendRequest request) {
         if (request.getRequester().getEmail().equals(request.getRecipient().getEmail())) {
             throw new PayException(ErrorCode.SELF_FRIEND_REQUEST);

--- a/src/test/http/friend.http
+++ b/src/test/http/friend.http
@@ -1,19 +1,23 @@
 ### 친구신청
 POST http://localhost:8080/friends/request
-Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0M0B0ZXN0LmNvbSIsImV4cCI6MTY4MDMzMzQ5NH0.x9TvUM1KET2qwBWbzi-BwNwNXH70lvUlS-tRFf5hxunf5SpJDE0r2jeDe_KR5EkuGxgojHjwO4pgjJ6uopjXsQ
+Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiZXhwIjoxNjgwMzUxMjUwfQ.VznCLWRPLsC-dxuMfi3aXtkv-5c-hZzFE_AsZlWTdgFsJnC4wyuUIAbIyh8Pd8QxFgfA7uRdngBFEkERTP1Yiw
 Content-Type: application/json
 
 {
   "name": "test",
   "password": "123456789",
-  "email": "test@test.com"
+  "email": "test3@test.com"
 }
 
 ### 친구 요청 목록 조회
 GET http://localhost:8080/friends/request?size=4
-Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiZXhwIjoxNjgwMzMzNTI2fQ.CZ5a04cd8aGsp_zBQFP600HRvkauFi1mZ3c7iorei_ta5J5gIR2v_hXF61GSKG3RCY6Y3mX7-aNAPiR86dzBKg
+Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0M0B0ZXN0LmNvbSIsImV4cCI6MTY4MDM1MTI4M30.fvU28wSkp0t9xNnZXGM4knMJJgdGxswfL_hgtNBuT2dCx1SXYaSVdsTneDcR2f-1g1hXsK94BjDroHwMzbzP-A
 Content-Type: application/json
 
 ### 친구 요청 수락
-POST http://localhost:8080/friends/request
+POST http://localhost:8080/friends/requests/accept/1
 Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiZXhwIjoxNjgwMzMzNTI2fQ.CZ5a04cd8aGsp_zBQFP600HRvkauFi1mZ3c7iorei_ta5J5gIR2v_hXF61GSKG3RCY6Y3mX7-aNAPiR86dzBKg
+
+### 친구 요청 거절
+POST http://localhost:8080/friends/requests/deny/1
+Auth: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0M0B0ZXN0LmNvbSIsImV4cCI6MTY4MDM1MTI4M30.fvU28wSkp0t9xNnZXGM4knMJJgdGxswfL_hgtNBuT2dCx1SXYaSVdsTneDcR2f-1g1hXsK94BjDroHwMzbzP-A

--- a/src/test/http/member.http
+++ b/src/test/http/member.http
@@ -5,7 +5,7 @@ Content-Type: application/json
 {
   "name": "test",
   "password": "123456789",
-  "email": "test3@test.com"
+  "email": "test@test.com"
 }
 
 ### 로그인
@@ -14,5 +14,5 @@ Content-Type: application/json
 
 {
   "password": "123456789",
-  "email": "test@test.com"
+  "email": "test3@test.com"
 }

--- a/src/test/java/com/jungmini/pay/controller/FriendControllerTest.java
+++ b/src/test/java/com/jungmini/pay/controller/FriendControllerTest.java
@@ -195,4 +195,33 @@ public class FriendControllerTest {
                 .andExpect(jsonPath("$.message").value(ErrorCode.UN_AUTHORIZED.getDescription()))
                 .andDo(print());
     }
+
+    @Test
+    @DisplayName("통합 테스트 성공 - 친구 요청 거절 성공")
+    void denyFriendRequest_success() throws Exception {
+        FriendRequest friendRequest = FriendRequestFactory.friendRequest();
+        Member requester = friendRequest.getRequester();
+        Member recipient = friendRequest.getRecipient();
+        memberService.signUp(requester);
+        memberService.signUp(recipient);
+        friendService.requestFriend(friendRequest);
+
+        String token = tokenService.generateToken(recipient.getEmail());
+
+        mvc.perform(post("/friends/requests/deny/1")
+                        .header("Auth", token))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.message").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("통합 테스트 성공 - 친구 요청 거절 실패 토큰 X")
+    void denyFriendRequest_fail() throws Exception {
+        mvc.perform(post("/friends/requests/deny/1"))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.UN_AUTHORIZED.toString()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.UN_AUTHORIZED.getDescription()))
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/jungmini/pay/service/FriendServiceTest.java
+++ b/src/test/java/com/jungmini/pay/service/FriendServiceTest.java
@@ -148,7 +148,7 @@ public class FriendServiceTest {
 
     @Test
     @DisplayName("친구 요청 수락 - 성공")
-    void acceptRequest_success() {
+    void acceptFriendRequest_success() {
         FriendRequest friendRequest = FriendRequestFactory.friendRequest();
         Friend friend = Friend.from(friendRequest);
 
@@ -166,12 +166,40 @@ public class FriendServiceTest {
 
     @Test
     @DisplayName("친구 요청 수락 - 실패 친구 요청 못 찾는 경우")
-    void acceptRequest_fail_friend_request_not_found() {
+    void acceptFriendRequest_fail_friend_request_not_found() {
         given(friendRequestRepository.findById(any()))
                 .willReturn(Optional.empty());
 
         PayException payException = assertThrows(PayException.class,
                 () -> friendService.acceptFriendRequest(1L));
+
+        assertThat(payException.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST.toString());
+        assertThat(payException.getErrorMessage()).isEqualTo(ErrorCode.BAD_REQUEST.getDescription());
+    }
+
+    @Test
+    @DisplayName("친구 요청 거절 - 성공")
+    void denyFriendRequest_success() {
+        FriendRequest friendRequest = FriendRequestFactory.friendRequest();
+        Friend friend = Friend.from(friendRequest);
+
+        given(friendRequestRepository.findById(any()))
+                .willReturn(Optional.of(friendRequest));
+
+        FriendRequest deletedFriendRequest = friendService.denyFriendRequest(1L);
+
+        assertThat(deletedFriendRequest.getRequester()).isEqualTo(friend.getRequester());
+        assertThat(deletedFriendRequest.getRecipient()).isEqualTo(friend.getRecipient());
+    }
+
+    @Test
+    @DisplayName("친구 요청 실패 - 실패 친구 요청 못 찾는 경우")
+    void denyFriendRequest_fail_friend_request_not_found() {
+        given(friendRequestRepository.findById(any()))
+                .willReturn(Optional.empty());
+
+        PayException payException = assertThrows(PayException.class,
+                () -> friendService.denyFriendRequest(1L));
 
         assertThat(payException.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST.toString());
         assertThat(payException.getErrorMessage()).isEqualTo(ErrorCode.BAD_REQUEST.getDescription());


### PR DESCRIPTION
feature 친구 요청 수락 기능 추가

단위 테스트 및 통합 테스트 작성 
예외 상황 1. 친구 요청이 존재하지 않는 경우 고민해 본 추가 

예외상황 

친구 요청을 수락할 때 회원이 탈퇴하거나 하는 경우에는 cascade 이용하여 정합성 보장 DB에서 제어할 수 있는 정합성 문제는 어플리케이션에서 고려하지 않는다.